### PR TITLE
Remove <path value="/"/> from CastleEngineManifest.xml

### DIFF
--- a/demos/basic/CastleEngineManifest.xml
+++ b/demos/basic/CastleEngineManifest.xml
@@ -7,7 +7,6 @@
 >
   <compiler_options>
     <search_paths>
-      <path value="/"/>
       <path value="../../src"/>
     </search_paths>
   </compiler_options>

--- a/demos/editor/CastleEngineManifest.xml
+++ b/demos/editor/CastleEngineManifest.xml
@@ -7,7 +7,6 @@
 >
   <compiler_options>
     <search_paths>
-      <path value="/"/>
       <path value="../../src"/>
     </search_paths>
   </compiler_options>


### PR DESCRIPTION
I see you used 

```
      <path value="/"/>
```

inside the `<search_paths>` in `CastleEngineManifest.xml`. I assume it is a mistake, it means probably something different than you wanted :)

- It means to just search literally `/` (the directory that you get if you `cd /` in terminal), which is "root directory" on Unix, and "root directory of current drive" on Windows. 

    In general, using absolute (or absolute within Windows drive) paths on `<search_paths>` is most likely a mistake. I added a warning about it to the build tool, so you would now see

    ```
    $ castle-engine compile
    castle-engine: Warning: Search path "/" is an absolute path, it will likely not work on other systems.
    ....
    ```

    You should use relative paths, and they are relative to the project root (that is, relative to `CastleEngineManifest.xml` location). I improved docs https://github.com/castle-engine/castle-engine/wiki/CastleEngineManifest.xml-examples/ to say it.

- What you wanted was probably to just say "include project top-level dir". 2 solutions for this:

    1. Do nothing :) We guarantee to include the root project dir in the search. This is done by having root project dir as current working directory when build tool executes FPC. I documented it on https://github.com/castle-engine/castle-engine/wiki/CastleEngineManifest.xml-examples .

    2. You could also use `<path value="."/>`  if you really want to say it explicitly :)
